### PR TITLE
feat(agent-discovery): Add DNS-AID, auth.md, and agent card discovery

### DIFF
--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -1,0 +1,35 @@
+{
+  "agent": "sametcelikbicak.com",
+  "version": "1.0.0",
+  "description": "Personal portfolio and professional profile site of Samet CELIKBICAK, Principal Software Specialist",
+  "protocols": {
+    "mcp": {
+      "endpoint": "https://sametcelikbicak.com/mcp",
+      "transport": "streamable-http",
+      "card": "https://sametcelikbicak.com/.well-known/mcp/server-card.json"
+    },
+    "a2a": {
+      "endpoint": "https://sametcelikbicak.com/",
+      "transport": "https"
+    }
+  },
+  "skills": [
+    {
+      "name": "profile-summary",
+      "type": "skill-md",
+      "url": "https://sametcelikbicak.com/.well-known/agent-skills/profile-summary/SKILL.md",
+      "description": "Public profile, project, and discovery guidance"
+    }
+  ],
+  "resources": [
+    "https://sametcelikbicak.com/llms.txt",
+    "https://sametcelikbicak.com/index.md",
+    "https://sametcelikbicak.com/openapi.json",
+    "https://sametcelikbicak.com/.well-known/api-catalog"
+  ],
+  "discovery": {
+    "dns-aid": "https://sametcelikbicak.com/.well-known/agent-card.json",
+    "sitemap": "https://sametcelikbicak.com/sitemap.xml",
+    "robots": "https://sametcelikbicak.com/robots.txt"
+  }
+}

--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -1,9 +1,20 @@
 {
   "issuer": "https://sametcelikbicak.com",
+  "resource": "https://sametcelikbicak.com/",
+  "authorization_servers": ["https://sametcelikbicak.com"],
+  "scopes_supported": ["public.read"],
+  "bearer_methods_supported": ["header"],
   "authorization_endpoint": "https://sametcelikbicak.com/docs/oauth.md#authorization",
   "token_endpoint": "https://sametcelikbicak.com/docs/oauth.md#token",
   "jwks_uri": "https://sametcelikbicak.com/.well-known/jwks.json",
   "response_types_supported": ["code"],
   "grant_types_supported": ["authorization_code"],
-  "scopes_supported": ["public.read"]
+  "agent_auth": {
+    "skill": "https://sametcelikbicak.com/auth.md",
+    "identity_types_supported": ["anonymous"],
+    "anonymous": {
+      "credential_types_supported": ["none"],
+      "claim_uri": "https://sametcelikbicak.com/docs/oauth.md"
+    }
+  }
 }

--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -1,6 +1,8 @@
 {
   "resource": "https://sametcelikbicak.com/",
+  "resource_name": "Samet CELIKBICAK Portfolio",
   "authorization_servers": ["https://sametcelikbicak.com"],
   "scopes_supported": ["public.read"],
+  "bearer_methods_supported": ["header"],
   "resource_documentation": "https://sametcelikbicak.com/docs/oauth.md"
 }

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,0 +1,61 @@
+# auth.md
+
+You are an agent. This site is a personal portfolio and blog hosted at `https://sametcelikbicak.com`. It exposes public read-only resources: profile information, blog posts, project listings, and an API catalog. There are no protected user-data APIs.
+
+## Step 1 — Discover
+
+Fetch the Protected Resource Metadata:
+
+```http
+GET /.well-known/oauth-protected-resource
+```
+
+Response:
+
+```json
+{
+  "resource": "https://sametcelikbicak.com/",
+  "resource_name": "Samet CELIKBICAK Portfolio",
+  "authorization_servers": ["https://sametcelikbicak.com"],
+  "scopes_supported": ["public.read"],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+Then fetch the Authorization Server metadata:
+
+```http
+GET /.well-known/oauth-authorization-server
+```
+
+Response includes an `agent_auth` block with registration details.
+
+## Step 2 — Pick a method
+
+This site accepts:
+
+- **anonymous** — no user identity required. Public resources only.
+
+`identity_assertion` methods (ID-JAG, verified email) are not currently supported because no user-specific data or write operations are exposed.
+
+## Step 3 — Register
+
+Since the site only serves public data, agents can operate without registration. Public resources are available at:
+
+- `https://sametcelikbicak.com/index.md` — full site markdown summary
+- `https://sametcelikbicak.com/llms.txt` — LLM site summary
+- `https://sametcelikbicak.com/openapi.json` — OpenAPI description
+- `https://sametcelikbicak.com/.well-known/api-catalog` — API catalog
+- `https://sametcelikbicak.com/sitemap.xml` — sitemap
+
+No access token is required to access these resources.
+
+## Errors
+
+| Code | Where | What to do |
+|------|-------|------------|
+| `invalid_request` | any | The request format is incorrect. Check the documentation. |
+
+## Revocation
+
+No credential revocation is needed because no access tokens are issued for public data.

--- a/public/docs/agent-discovery.md
+++ b/public/docs/agent-discovery.md
@@ -3,9 +3,21 @@
 This site publishes machine-readable discovery resources for AI agents,
 crawlers, and search systems.
 
+- `/.well-known/agent-card.json` provides the DNS-AID agent card for AI agent discovery.
 - `/.well-known/api-catalog` provides a Linkset catalog for discovery.
+- `/.well-known/mcp/server-card.json` provides the MCP server capabilities.
+- `/.well-known/agent-skills/index.json` provides discoverable agent skills.
 - `/llms.txt` summarizes the site, audience, topics, and trusted facts.
 - `/sitemap.xml` lists canonical crawl targets.
 - `/robots.txt` declares crawler access rules, including AI crawler access.
+
+- `/auth.md` provides agent registration instructions (auth.md standard).
+
+## DNS for AI Discovery (DNS-AID)
+
+This domain publishes DNS-AID records for agent discovery:
+
+- `_a2a._agents.sametcelikbicak.com` — Agent-to-Agent protocol SVCB record
+- `_index._agents.sametcelikbicak.com` — Organization agent index SVCB record
 
 The primary site authority is `https://sametcelikbicak.com/`.

--- a/public/docs/oauth.md
+++ b/public/docs/oauth.md
@@ -14,3 +14,10 @@ No authorization endpoint is currently active for third-party clients.
 ## Token
 
 No token endpoint is currently active for third-party clients.
+
+## Agent Registration
+
+Agents can discover registration instructions at `/auth.md`.
+See [auth.md](/auth.md) for the agentic registration flow.
+
+Anonymous registration is supported for public read-only access.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -52,10 +52,12 @@ Until 2024, Samet worked as a Fullstack Developer. Since 2024, he has continued 
 - OpenAPI: https://sametcelikbicak.com/openapi.json
 - Sitemap: https://sametcelikbicak.com/sitemap.xml
 - Robots: https://sametcelikbicak.com/robots.txt
+- Agent card: https://sametcelikbicak.com/.well-known/agent-card.json
+- Auth.md: https://sametcelikbicak.com/auth.md
 `;
 
 const LINK_HEADER =
-  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </openapi.json>; rel="service-desc"; type="application/vnd.oai.openapi+json", </docs/api.md>; rel="service-doc"; type="text/markdown", </status/health.json>; rel="status"; type="application/json", </llms.txt>; rel="describedby"; type="text/plain", </index.md>; rel="alternate"; type="text/markdown"';
+  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </openapi.json>; rel="service-desc"; type="application/vnd.oai.openapi+json", </docs/api.md>; rel="service-doc"; type="text/markdown", </status/health.json>; rel="status"; type="application/json", </llms.txt>; rel="describedby"; type="text/plain", </auth.md>; rel="describedby"; type="text/markdown", </index.md>; rel="alternate"; type="text/markdown", </.well-known/agent-card.json>; rel="agent-card"; type="application/json"';
 
 const CONTENT_TYPES = new Map<string, string>([
   ['/.well-known/api-catalog', 'application/linkset+json; charset=utf-8'],
@@ -67,11 +69,13 @@ const CONTENT_TYPES = new Map<string, string>([
   ['/.well-known/oauth-protected-resource', 'application/json; charset=utf-8'],
   ['/.well-known/jwks.json', 'application/json; charset=utf-8'],
   ['/.well-known/mcp/server-card.json', 'application/json; charset=utf-8'],
+  ['/.well-known/agent-card.json', 'application/json; charset=utf-8'],
   ['/.well-known/agent-skills/index.json', 'application/json; charset=utf-8'],
   [
     '/.well-known/agent-skills/profile-summary/SKILL.md',
     'text/markdown; charset=utf-8',
   ],
+  ['/auth.md', 'text/markdown; charset=utf-8'],
   ['/index.md', 'text/markdown; charset=utf-8'],
   ['/openapi.json', 'application/vnd.oai.openapi+json; charset=utf-8'],
   ['/status/health.json', 'application/json; charset=utf-8'],


### PR DESCRIPTION
- Add DNS-AID SVCB records for _a2a._agents and _index._agents
- Create /.well-known/agent-card.json for agent capability discovery
- Create /auth.md for agent registration (auth.md standard)
- Update OAuth metadata with agent_auth block and bearer_methods_supported
- Update worker.ts with content types and Link headers
- Update docs references